### PR TITLE
Fix empty list indexing issue

### DIFF
--- a/ddtrace/internal/processor/trace.py
+++ b/ddtrace/internal/processor/trace.py
@@ -229,7 +229,7 @@ class SpanAggregator(SpanProcessor):
 
                 num_finished = len(finished)
 
-                if should_partial_flush:
+                if should_partial_flush and num_finished > 0:
                     log.debug("Partially flushing %d spans for trace %d", num_finished, span.trace_id)
                     finished[0].set_metric("_dd.py.partial_flush", num_finished)
 


### PR DESCRIPTION
This PR has the same purpose as #3, so I've copied it's description below:
***
## What's changing?

This replicates an [upstream change](https://github.com/DataDog/dd-trace-py/commit/9cf79fcb7dd1e5daf0f4e3211c6d1d0ac2f928df#diff-d605e0d53475786febed09aa2b562f6b2458230ba5353cf5b93f4e1ec631556aR235) from `dd-trace-py` to that we have metrics to partially flush 

## Why is it changing?

The `finished[0]` fails if `num_finished` is 0 :)